### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/example/requests/main.dart
+++ b/example/requests/main.dart
@@ -23,7 +23,7 @@ Future<String> getUrl(String url) async {
   StringBuffer contents = new StringBuffer();
   var request = await HttpClient().getUrl(Uri.parse(url));
   var response = await request.close(); 
- response.transform(utf8.decoder).listen((String data) {
+  response.cast<List<int>>().transform(utf8.decoder).listen((String data) {
     contents.write(data);
   }, onDone: () => completer.complete(contents.toString()));
   return await completer.future;


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900